### PR TITLE
Feature: 조회수 증가 구현 & 서비스에서 엔티티 대신 DTO 반환

### DIFF
--- a/src/main/java/com/savannah030/ViLLAGER/controller/BoardController.java
+++ b/src/main/java/com/savannah030/ViLLAGER/controller/BoardController.java
@@ -1,8 +1,11 @@
 package com.savannah030.ViLLAGER.controller;
 
 import com.savannah030.ViLLAGER.dto.MyBoardResponseDto;
+import com.savannah030.ViLLAGER.repository.BoardRepository;
 import com.savannah030.ViLLAGER.service.BoardService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -24,10 +27,10 @@ public class BoardController {
 
     @GetMapping("/form")
     public String form(@RequestParam(value="idx", defaultValue = "0")Long idx, Model model){
-        log.info("BoardController form");
-        MyBoardResponseDto dto = boardService.findMyBoardByIdx(idx);
+        MyBoardResponseDto dto = boardService.findMyBoardByIdx(idx); // 조회수 증가
         model.addAttribute("boardResponseDto", dto);
-        log.info("boardResponseDto: {}", dto);
+        log.info("BoardController");
+        log.info("dto에 조회수 증가 적용되는지: {}, {}", dto.getIdx(), dto.getHits()); //ok
         return "/board/form";
     }
 

--- a/src/main/java/com/savannah030/ViLLAGER/controller/BoardController.java
+++ b/src/main/java/com/savannah030/ViLLAGER/controller/BoardController.java
@@ -1,6 +1,8 @@
 package com.savannah030.ViLLAGER.controller;
 
+import com.savannah030.ViLLAGER.dto.MyBoardResponseDto;
 import com.savannah030.ViLLAGER.service.BoardService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -9,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+@Slf4j
 @Controller
 @RequestMapping("/board")
 public class BoardController {
@@ -19,17 +22,13 @@ public class BoardController {
         this.boardService = boardService;
     }
 
-
-    @GetMapping("/form-save")
-    public String formSave() {
-        return "/board/form-save";
-    }
-
-
-    @GetMapping("/form-update")
-    public String formUpdate(@RequestParam(value="idx", defaultValue = "0")Long idx, Model model){
-        model.addAttribute("board", boardService.findBoardByIdx(idx));
-        return "/board/form-update";
+    @GetMapping("/form")
+    public String form(@RequestParam(value="idx", defaultValue = "0")Long idx, Model model){
+        log.info("BoardController form");
+        MyBoardResponseDto dto = boardService.findMyBoardByIdx(idx);
+        model.addAttribute("boardResponseDto", dto);
+        log.info("boardResponseDto: {}", dto);
+        return "/board/form";
     }
 
     @GetMapping("/list")

--- a/src/main/java/com/savannah030/ViLLAGER/domain/entity/Board.java
+++ b/src/main/java/com/savannah030/ViLLAGER/domain/entity/Board.java
@@ -4,13 +4,12 @@ import com.savannah030.ViLLAGER.domain.BaseEntity;
 import com.savannah030.ViLLAGER.domain.components.Address;
 import com.savannah030.ViLLAGER.domain.enums.CategoryType;
 import com.savannah030.ViLLAGER.domain.enums.StatusType;
-import com.savannah030.ViLLAGER.dto.BoardDto;
+import com.savannah030.ViLLAGER.dto.BoardUpdateRequestDto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -62,7 +61,7 @@ public class Board extends BaseEntity {
     }
 
     // NOTE: 영속성 컨텍스트
-    public void update(BoardDto boardDto){
+    public void update(BoardUpdateRequestDto boardDto){
         this.categoryType = boardDto.getCategoryType();
         this.title = boardDto.getTitle();
         this.content = boardDto.getContent();

--- a/src/main/java/com/savannah030/ViLLAGER/domain/entity/Board.java
+++ b/src/main/java/com/savannah030/ViLLAGER/domain/entity/Board.java
@@ -70,7 +70,7 @@ public class Board extends BaseEntity {
         this.address = new Address(boardDto.getLatitude(), boardDto.getLongitude());
     }
 
-    public void increaseHits(Board board){
+    public void increaseHits(){
         this.hits += 1;
     }
 

--- a/src/main/java/com/savannah030/ViLLAGER/dto/BoardListResponseDto.java
+++ b/src/main/java/com/savannah030/ViLLAGER/dto/BoardListResponseDto.java
@@ -1,0 +1,36 @@
+package com.savannah030.ViLLAGER.dto;
+
+import com.savannah030.ViLLAGER.domain.entity.Board;
+import com.savannah030.ViLLAGER.domain.enums.CategoryType;
+import com.savannah030.ViLLAGER.domain.enums.StatusType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@NoArgsConstructor
+@Getter
+public class BoardListResponseDto {
+
+    private Long idx;
+
+    private CategoryType categoryType;
+
+    private String title;
+
+    private String content;
+
+    private StatusType statusType;
+
+    private Long hits;
+
+    @Builder
+    public BoardListResponseDto(Board entity){
+        this.idx = entity.getIdx();
+        this.categoryType = entity.getCategoryType();
+        this.title = entity.getTitle();
+        this.content = entity.getContent();
+        this.statusType = entity.getStatusType();
+        this.hits = entity.getHits();
+    }
+}

--- a/src/main/java/com/savannah030/ViLLAGER/dto/BoardSaveRequestDto.java
+++ b/src/main/java/com/savannah030/ViLLAGER/dto/BoardSaveRequestDto.java
@@ -1,5 +1,7 @@
 package com.savannah030.ViLLAGER.dto;
 
+import com.savannah030.ViLLAGER.domain.components.Address;
+import com.savannah030.ViLLAGER.domain.entity.Board;
 import com.savannah030.ViLLAGER.domain.enums.CategoryType;
 import lombok.*;
 
@@ -24,5 +26,14 @@ public class BoardSaveRequestDto {
         this.content = content;
         this.latitude = latitude;
         this.longitude = longitude;
+    }
+
+    public Board toEntity() {
+        return Board.builder()
+                .categoryType(categoryType)
+                .title(title)
+                .content(content)
+                .address(new Address(latitude,longitude))
+                .build();
     }
 }

--- a/src/main/java/com/savannah030/ViLLAGER/dto/MyBoardResponseDto.java
+++ b/src/main/java/com/savannah030/ViLLAGER/dto/MyBoardResponseDto.java
@@ -1,0 +1,49 @@
+package com.savannah030.ViLLAGER.dto;
+
+import com.savannah030.ViLLAGER.domain.entity.Board;
+import com.savannah030.ViLLAGER.domain.enums.CategoryType;
+import com.savannah030.ViLLAGER.domain.enums.StatusType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Getter
+public class MyBoardResponseDto {
+
+    private LocalDateTime createdDate;
+
+    private LocalDateTime updatedDate;
+
+    private Long idx;
+
+    private CategoryType categoryType;
+
+    private String title;
+
+    private String content;
+
+    private StatusType statusType;
+
+    private Long hits;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    @Builder
+    public MyBoardResponseDto(Board entity){
+        this.idx = entity.getIdx();
+        this.createdDate = entity.getCreatedDate();
+        this.updatedDate = entity.getUpdatedDate();
+        this.categoryType = entity.getCategoryType();
+        this.title = entity.getTitle();
+        this.content = entity.getContent();
+        this.statusType = entity.getStatusType();
+        this.hits = entity.getHits();
+        //this.latitude = entity.getAddress().getLatitude();
+        //this.longitude = entity.getAddress().getLongitude();
+    }
+}

--- a/src/main/java/com/savannah030/ViLLAGER/service/BoardService.java
+++ b/src/main/java/com/savannah030/ViLLAGER/service/BoardService.java
@@ -34,13 +34,30 @@ public class BoardService {
         return ReturnCode.SUCCESS;
     }
 
+    @Transactional
+    public void increaseHits(Board board){
+        log.info("BoardService increaseHits @Transactional");
+        log.info("increaseHits 전: {}, {}", board.getIdx(), board.getHits());
+        board.increaseHits();
+        log.info("increaseHits 후: {}, {}", board.getIdx(), board.getHits());
+    }
     // READ
     // TODO: 다른사람의 게시글 찾는 것도 구현해야함
+    @Transactional
     public MyBoardResponseDto findMyBoardByIdx(Long idx){
         // NOTE: 엔티티 객체 찾아서 있으면 그 엔티티를 DTO로 변환해서 반환
         //  엔티티 없으면 일단 새로운 DTO를 반환하기
         //  엔티티 생성은 BoardService.createBoard에서!!!! (저장버튼 누를 때)
         Optional<Board> entity = boardRepository.findById(idx);
+        // 엔티티 있으면
+        /** if(entity.isPresent()){
+         *      increaseHits(entity.get());
+         *  }
+         */
+        log.info("BoardService findMyBoardByIdx");
+        log.info("findMyBoardByIdx 전: {}, {}", entity.get().getIdx(), entity.get().getHits());
+        entity.ifPresent(this::increaseHits);
+        log.info("findMyBoardByIdx 후: {}, {}", entity.get().getIdx(), entity.get().getHits());
         return entity.map(MyBoardResponseDto::new).orElseGet(MyBoardResponseDto::new);
     }
 

--- a/src/main/java/com/savannah030/ViLLAGER/service/BoardService.java
+++ b/src/main/java/com/savannah030/ViLLAGER/service/BoardService.java
@@ -41,38 +41,9 @@ public class BoardService {
         //  엔티티 없으면 일단 새로운 DTO를 반환하기
         //  엔티티 생성은 BoardService.createBoard에서!!!! (저장버튼 누를 때)
         Optional<Board> entity = boardRepository.findById(idx);
-        /**
-         * // 엔티티 객체 없으면
-         *  if (!entity.isPresent()){
-         *      return new MyBoardResponseDto();
-         *      }
-         *  // 엔티티 객체 있으면
-         *  else{
-         *      return new MyBoardResponseDto(entity.get());
-         *  }
-         */
         return entity.map(MyBoardResponseDto::new).orElseGet(MyBoardResponseDto::new);
-
-         /**
-          * 시도1: 해당 idx를 갖는 엔티티를 찾고 없으면 새로운 엔티티를 생성
-          * 그 다음에 dto로 반환
-          * -> 문제점: new Board()에서 엔티티가 제대로 초기화되지 않아서 NULLPOINTERXCEPTION 발생
-        log.info("BoardService findMyBoardByIdx");
-        Board entity = boardRepository.findById(idx).orElse(new Board());
-        log.info("entity: {}",entity);
-        log.info("idx: {}" ,entity.getIdx());
-        // DTO로 변환해서 반환
-        return new MyBoardResponseDto(entity);
-         */
-        //
-
     }
 
-    /**
-     *
-     * @param pageable
-     * @return
-     */
     // READ LIST
     public Page<Board> findBoardList(Pageable pageable) {
         pageable = PageRequest.of(pageable.getPageNumber() <= 0 ? 0 : pageable.getPageNumber()-1, pageable.getPageSize());

--- a/src/main/java/com/savannah030/ViLLAGER/service/BoardService.java
+++ b/src/main/java/com/savannah030/ViLLAGER/service/BoardService.java
@@ -34,13 +34,6 @@ public class BoardService {
         return ReturnCode.SUCCESS;
     }
 
-    @Transactional
-    public void increaseHits(Board board){
-        log.info("BoardService increaseHits @Transactional");
-        log.info("increaseHits 전: {}, {}", board.getIdx(), board.getHits());
-        board.increaseHits();
-        log.info("increaseHits 후: {}, {}", board.getIdx(), board.getHits());
-    }
     // READ
     // TODO: 다른사람의 게시글 찾는 것도 구현해야함
     @Transactional
@@ -50,13 +43,14 @@ public class BoardService {
         //  엔티티 생성은 BoardService.createBoard에서!!!! (저장버튼 누를 때)
         Optional<Board> entity = boardRepository.findById(idx);
         // 엔티티 있으면
-        /** if(entity.isPresent()){
-         *      increaseHits(entity.get());
-         *  }
-         */
         log.info("BoardService findMyBoardByIdx");
         log.info("findMyBoardByIdx 전: {}, {}", entity.get().getIdx(), entity.get().getHits());
-        entity.ifPresent(this::increaseHits);
+        /**
+         * if (entity.isPresent()){
+         *      entity.get().increaseHits();
+         * }
+         */
+        entity.ifPresent(Board::increaseHits);
         log.info("findMyBoardByIdx 후: {}, {}", entity.get().getIdx(), entity.get().getHits());
         return entity.map(MyBoardResponseDto::new).orElseGet(MyBoardResponseDto::new);
     }

--- a/src/main/resources/static/js/kakao-map/createMap.js
+++ b/src/main/resources/static/js/kakao-map/createMap.js
@@ -1,0 +1,9 @@
+/////////////////////////지도///////////////////////////////////
+const mapContainer = document.getElementById('map'), // 지도를 표시할 div
+    mapOption = {
+        center: new kakao.maps.LatLng(37.48603206504228,126.98308494303069 ), // 지도의 중심좌표
+        level: 3 // 지도의 확대 레벨
+    };
+
+const map = new kakao.maps.Map(mapContainer, mapOption); // 지도를 생성합니다
+/////////////////////////////////////////////////////////////////

--- a/src/main/resources/templates/board/form.html
+++ b/src/main/resources/templates/board/form.html
@@ -19,12 +19,12 @@
         <!-- createdDate -->
         <tr>
             <th style="padding:13px 0 0 15px;">생성날짜</th>
-            <td><input type="text" class="col-md-8 form-control input-sm" readonly="readonly" th:value="${boardResponseDto?.createdDate} ? ${#temporals.format(boardResponseDto.createdDate,'yyyy-MM-dd HH:mm')} : ${board?.createdDate}"/></td>
+            <td><input type="text" class="col-md-8 form-control input-sm" readonly="readonly" th:value="${boardResponseDto?.createdDate} ? ${#temporals.format(boardResponseDto.createdDate,'yyyy-MM-dd HH:mm')} : ${boardResponseDto?.createdDate}"/></td>
         </tr>
         <!-- updatedDate -->
         <tr>
             <th style="padding:13px 0 0 15px;">수정날짜</th>
-            <td><input type="text" class="col-md-8 form-control input-sm" readonly="readonly" th:value="${boardResponseDto?.updatedDate} ? ${#temporals.format(boardResponseDto.updatedDate,'yyyy-MM-dd HH:mm')} : ${board?.updatedDate}"/></td>
+            <td><input type="text" class="col-md-8 form-control input-sm" readonly="readonly" th:value="${boardResponseDto?.updatedDate} ? ${#temporals.format(boardResponseDto.updatedDate,'yyyy-MM-dd HH:mm')} : ${boardResponseDto?.updatedDate}"/></td>
         </tr>
         <!-- categoryType -->
         <tr>
@@ -65,7 +65,11 @@
                 </div>
             </td>
         </tr>
-
+        <!-- hits -->
+        <tr>
+            <th style="padding:13px 0 0 15px;">조회수</th>
+            <td> <input type="text" class="col-md-8 form-control input-sm" readonly="readonly" th:value="${boardResponseDto?.hits}"/> </td>
+        </tr>
     </table>
     <div class="pull-left">
         <a href="/board/list" class="btn btn-default">목록으로</a>

--- a/src/main/resources/templates/board/form.html
+++ b/src/main/resources/templates/board/form.html
@@ -14,18 +14,17 @@
         <h1>게시글 등록</h1>
     </div>
     <br/>
-    <input id="board_idx" type="hidden" th:value="${board?.idx}"/>
-    <input id="board_create_date" type="hidden" th:value="${board?.createdDate}"/>
+    <input id="board_idx" type="hidden" th:value="${boardResponseDto?.idx}"/>
     <table class="table">
         <!-- createdDate -->
         <tr>
             <th style="padding:13px 0 0 15px;">생성날짜</th>
-            <td><input type="text" class="col-md-8 form-control input-sm" readonly="readonly" th:value="${board?.createdDate} ? ${#temporals.format(board.createdDate,'yyyy-MM-dd HH:mm')} : ${board?.createdDate}"/></td>
+            <td><input type="text" class="col-md-8 form-control input-sm" readonly="readonly" th:value="${boardResponseDto?.createdDate} ? ${#temporals.format(boardResponseDto.createdDate,'yyyy-MM-dd HH:mm')} : ${board?.createdDate}"/></td>
         </tr>
         <!-- updatedDate -->
         <tr>
             <th style="padding:13px 0 0 15px;">수정날짜</th>
-            <td><input type="text" class="col-md-8 form-control input-sm" readonly="readonly" th:value="${board?.updatedDate} ? ${#temporals.format(board.updatedDate,'yyyy-MM-dd HH:mm')} : ${board?.updatedDate}"/></td>
+            <td><input type="text" class="col-md-8 form-control input-sm" readonly="readonly" th:value="${boardResponseDto?.updatedDate} ? ${#temporals.format(boardResponseDto.updatedDate,'yyyy-MM-dd HH:mm')} : ${board?.updatedDate}"/></td>
         </tr>
         <!-- categoryType -->
         <tr>
@@ -34,8 +33,8 @@
                 <div class="pull-left">
                     <select class="col-md-8 form-control input-sm" id="board_category">
                         <option>--분류--</option>
-                        <option th:value="CLOTHES" th:selected="${board?.categoryType?.name() == 'CLOTHES'}">옷</option> <!--NOTE: th:value도 대문자로 써야 json 파싱에러 안남 -->
-                        <option th:value="ELECTRONICS" th:selected="${board?.categoryType?.name() == 'ELECTRONICS'}">전자기기</option>
+                        <option th:value="CLOTHES" th:selected="${boardResponseDto?.categoryType?.name() == 'CLOTHES'}">옷</option> <!--NOTE: th:value도 대문자로 써야 json 파싱에러 안남 -->
+                        <option th:value="ELECTRONICS" th:selected="${boardResponseDto?.categoryType?.name() == 'ELECTRONICS'}">전자기기</option>
                     </select>
                 </div>
             </td>
@@ -43,13 +42,13 @@
         <!-- title -->
         <tr>
             <th style="padding:13px 0 0 15px;">제목</th>
-            <td><input id="board_title" type="text" class="col-md-8 form-control input-sm" th:value="${board?.title}"/></td>
+            <td><input id="board_title" type="text" class="col-md-8 form-control input-sm" th:value="${boardResponseDto?.title}"/></td>
         </tr>
         <!-- content -->
         <tr>
             <th style="padding:13px 0 0 15px;">내용</th>
             <td><textarea id="board_content" class="col-md-8 form-control input-sm" maxlength="140" rows="7" style="height: 200px;"
-                          th:text="${board?.content}"></textarea><span class="help-block"></span>
+                          th:text="${boardResponseDto?.content}"></textarea><span class="help-block"></span>
             </td>
         </tr>
         <!-- statusType -->
@@ -57,11 +56,11 @@
             <th style="padding:13px 0 0 15px">판매 상태</th> <!-- 글을 수정할때만 판매 상태 바꿀 수 있도록 -->
             <td>
                 <div class="pull-left">
-                    <select th:disabled="!${board?.idx}" class="col-md-8 form-control input-sm" id="board_status">
+                    <select th:disabled="!${boardResponseDto?.idx}" class="col-md-8 form-control input-sm" id="board_status">
                         <option>--분류--</option>
-                        <option th:value="ONSALE" th:selected="${board?.statusType?.name() == 'ONSALE'}">판매중</option> <!--NOTE: th:value도 대문자로 써야 json 파싱에러 안남 -->
-                        <option th:value="RESERVED" th:selected="${board?.statusType?.name() == 'RESERVED'}">예약중</option>
-                        <option th:value="SOLDOUT" th:selected="${board?.statusType?.name() == 'SOLDOUT'}">판매완료</option>
+                        <option th:value="ONSALE" th:selected="${boardResponseDto?.statusType?.name() == 'ONSALE'}">판매중</option> <!--NOTE: th:value도 대문자로 써야 json 파싱에러 안남 -->
+                        <option th:value="RESERVED" th:selected="${boardResponseDto?.statusType?.name() == 'RESERVED'}">예약중</option>
+                        <option th:value="SOLDOUT" th:selected="${boardResponseDto?.statusType?.name() == 'SOLDOUT'}">판매완료</option>
                     </select>
                 </div>
             </td>
@@ -72,9 +71,9 @@
         <a href="/board/list" class="btn btn-default">목록으로</a>
     </div>
     <div class="pull-right">
-        <button th:if="!${board?.idx}" type="button" class="btn btn-primary" id="btn-save">저장</button>
-        <button th:if="${board?.idx}" type="button" class="btn btn-info" id="btn-update">수정</button>
-        <button th:if="${board?.idx}" type="button" class="btn btn-danger" id="btn-delete">삭제</button>
+        <button th:if="!${boardResponseDto?.idx}" type="button" class="btn btn-primary" id="btn-save">저장</button>
+        <button th:if="${boardResponseDto?.idx}" type="button" class="btn btn-info" id="btn-update">수정</button>
+        <button th:if="${boardResponseDto?.idx}" type="button" class="btn btn-danger" id="btn-delete">삭제</button>
     </div>
 </div>
 

--- a/src/main/resources/templates/place.html
+++ b/src/main/resources/templates/place.html
@@ -11,8 +11,10 @@
 
     <!--body-->
     <button type="button" class="btn btn-primary" id="btn_findNearPlaces">장소불러오기</button>
+    <div id="map" style="width:500px;height:400px;"></div>
     <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=f63a467df66083374b05cd46e6144a23"></script>
-    <script src="../static/js/app/place.js"></script>
+    <script type="text/javascript" src="js/kakao-map/createMap.js"></script>
+    <script src="js/app/place.js"></script>
     <!--/body-->
 
     <div th:replace="layout/footer::footer"></div>


### PR DESCRIPTION
## 조회수 증가 구현

1. 엔티티에 increaseHits() 함수를 구현해서 서비스단에서 함수 호출하도록!
2. 서비스단에 `@Transactional`을 붙여야 엔티티 수정사항이 반영된다.

## 서비스에서 DTO를 반환
 - 엔티티를 직접 반환하지 않음


### 사용자가 글 작성 or 수정하려하면
1. BoardController에서 `@GetMapping("/board/form?idx=value")` 처리
2. BoardService의 findMyBoardIdx함수에서 
2-1. 해당 idx를 갖는 글이 있으면(수정하는 경우) board 엔티티를 boardResponseDto로 변환해서 리턴
2-2. 해당 idx의 글이 없으면(새로 작성하는 경우) **엔티티를 생성하지 않고** boardResponseDto만 리턴
(board 엔티티는 '저장' 버튼을 눌렀을 때 BoardService.createBoard에서 생성)
3. 컨트롤러의 처리 결과를 모델에 넣고 뷰를 리턴
    
### 사용자가 글 목록을 보려 하면

1. BoardController에서 `@GetMapping("/board/list")` 처리
2. BoardService의 findBoardList에서 Pageable한 Board 엔티티를 모두 찾고 BoardListResponseDto로 변환하여 리턴
3. 컨트롤러의 처리 결과를 모델에 넣고 뷰를 리턴


## 배운 것
#### 자바 스트림
    
```java
Page<Board> boardList = boardRepository.findAll(pageable);
        // NOTE: 자바 stream 공부하기!!
        return new PageImpl<>(boardList.stream()
	       				.map(BoardListResponseDto::new)
                                        .collect(Collectors.toList()),
                                        pageable,boardList.getTotalElements());
```
#### 자바 Optional
- 이랬던 코드를
```java
// 엔티티 객체 없으면(글을 새로 쓰는 경우) 필드 값을 초기화하지않은 dto 생성 
if (!entity.isPresent()){
    return new MyBoardResponseDto();
}
// 엔티티 객체 있으면 그 객체의 필드로 dto 초기화
else{
    return new MyBoardResponseDto(entity.get());
}
```
- 이렇게 바꿀 수 있다
```java
//
// orElseGet(Supplier<? extends T> other)는 Optional에 값이 없을 때만 Supplier 실행 
entity.map(MyBoardResponseDto::new).orElseGet(MyBoardResponseDto::new);
```

- 이랬던 코드를2
```java
if(entity.isPresent()){
	entity.get().increaseHits()
}
```
- 이렇게 바꿀 수 있다2 
```java
entity.ifPresent(Board::increaseHits);
```