### PR TITLE
Feature: 카카오지도 api 연동해서 '근처 판매글 불러오기' 버튼 누르면 DB에서 글 데이터 갖고와서 뿌리기

### DIFF
--- a/src/main/java/com/savannah030/ViLLAGER/controller/PlaceController.java
+++ b/src/main/java/com/savannah030/ViLLAGER/controller/PlaceController.java
@@ -1,35 +1,14 @@
 package com.savannah030.ViLLAGER.controller;
 
-import com.savannah030.ViLLAGER.domain.Location;
-import com.savannah030.ViLLAGER.repository.BoardRepository;
-import com.savannah030.ViLLAGER.service.PlaceService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.ui.Model;
 
 @Controller
 @RequestMapping("/place")
 public class PlaceController {
-
-    @Autowired
-    private BoardRepository boardRepository;
-
-    @GetMapping({"", "/"})
-    public String place(Model model){
-        model.addAttribute("boardList", boardRepository.findAll());
-        return "place";
+    @GetMapping
+    public String place(){
+        return "/place";
     }
-    /*
-    @Autowired
-    private PlaceService placeService;
-
-    @GetMapping({"", "/"})
-    public String place(Position position, Model model){
-        model.addAttribute("place", placeService.findNearPlaces());
-    }
-    */
-
 }

--- a/src/main/java/com/savannah030/ViLLAGER/controller/PlaceRestController.java
+++ b/src/main/java/com/savannah030/ViLLAGER/controller/PlaceRestController.java
@@ -1,0 +1,31 @@
+package com.savannah030.ViLLAGER.controller;
+
+import com.savannah030.ViLLAGER.domain.components.Address;
+import com.savannah030.ViLLAGER.service.PlaceService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/places")
+public class PlaceRestController {
+
+    private final PlaceService placeService;
+    @GetMapping
+    public ResponseEntity<?> getPlaces(@RequestParam(value="lat")Double latitude, @RequestParam(value="lon")Double longitude){
+        log.info("lat: {}, lon: {}",latitude,longitude); // ok
+        return Optional.ofNullable(placeService.findNearPlaces(new Address(latitude,longitude)))
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.noContent().build());
+
+    }
+
+
+}

--- a/src/main/java/com/savannah030/ViLLAGER/dto/MarkerResponseDto.java
+++ b/src/main/java/com/savannah030/ViLLAGER/dto/MarkerResponseDto.java
@@ -1,0 +1,21 @@
+package com.savannah030.ViLLAGER.dto;
+
+import com.savannah030.ViLLAGER.domain.entity.Board;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 게시글을 마커에 찍을 때 사용할 dto
+// 따라서 Board 엔티티의 필드 중 위도, 경도만 갖고 온다.
+@NoArgsConstructor
+@Getter
+public class MarkerResponseDto {
+    private Double latitude;
+    private Double longitude;
+
+    @Builder
+    public MarkerResponseDto(Board entity) {// Board 엔티티의 정보를 갖고 온다
+        this.latitude = entity.getAddress().getLatitude();
+        this.longitude = entity.getAddress().getLongitude();
+    }
+}

--- a/src/main/java/com/savannah030/ViLLAGER/dto/OverlayResponseDto.java
+++ b/src/main/java/com/savannah030/ViLLAGER/dto/OverlayResponseDto.java
@@ -1,0 +1,27 @@
+package com.savannah030.ViLLAGER.dto;
+
+import com.savannah030.ViLLAGER.domain.entity.Board;
+import com.savannah030.ViLLAGER.domain.enums.CategoryType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class OverlayResponseDto {
+    private Long idx;
+    private CategoryType categoryType;
+    private String title;
+    private Double latitude;
+    private Double longitude;
+
+
+    @Builder
+    public OverlayResponseDto(Board entity) {// Board 엔티티의 정보를 갖고 온다
+        this.idx = entity.getIdx();
+        this.categoryType = entity.getCategoryType();
+        this.title = entity.getTitle();
+        this.latitude = entity.getAddress().getLatitude();
+        this.longitude = entity.getAddress().getLongitude();
+    }
+}

--- a/src/main/java/com/savannah030/ViLLAGER/service/PlaceService.java
+++ b/src/main/java/com/savannah030/ViLLAGER/service/PlaceService.java
@@ -3,7 +3,6 @@ package com.savannah030.ViLLAGER.service;
 import com.savannah030.ViLLAGER.domain.components.Address;
 import com.savannah030.ViLLAGER.domain.entity.Board;
 import com.savannah030.ViLLAGER.dto.MarkerResponseDto;
-import com.savannah030.ViLLAGER.dto.MyBoardResponseDto;
 import com.savannah030.ViLLAGER.dto.OverlayResponseDto;
 import com.savannah030.ViLLAGER.repository.BoardRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,9 +23,9 @@ public class PlaceService {
     public List<List<?>> findNearPlaces(Address address){
         List<List<?>> results = new ArrayList<>();
         List<Board> boardList = boardRepository.findAllByLatitudeAndLongitude(address.getLatitude(), address.getLongitude());
-        List<MarkerResponseDto> markerList = boardList.stream().map(MarkerResponseDto::new).collect(Collectors.toList());
+        //List<MarkerResponseDto> markerList = boardList.stream().map(MarkerResponseDto::new).collect(Collectors.toList());
         List<OverlayResponseDto> overlayList = boardList.stream().map(OverlayResponseDto::new).collect(Collectors.toList());
-        results.add(markerList);
+        //results.add(markerList);
         results.add(overlayList);
         return results;
     }

--- a/src/main/java/com/savannah030/ViLLAGER/service/PlaceService.java
+++ b/src/main/java/com/savannah030/ViLLAGER/service/PlaceService.java
@@ -1,21 +1,63 @@
 package com.savannah030.ViLLAGER.service;
 
-import com.savannah030.ViLLAGER.domain.Location;
+import com.savannah030.ViLLAGER.domain.components.Address;
+import com.savannah030.ViLLAGER.domain.entity.Board;
+import com.savannah030.ViLLAGER.dto.MarkerResponseDto;
+import com.savannah030.ViLLAGER.dto.MyBoardResponseDto;
+import com.savannah030.ViLLAGER.dto.OverlayResponseDto;
 import com.savannah030.ViLLAGER.repository.BoardRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class PlaceService {
 
-    /*
-    @Autowired
-    private BoardRepository boardRepository;
+    private final BoardRepository boardRepository;
 
-    public List<Location> findNearPlaces(){
-
+    public List<List<?>> findNearPlaces(Address address){
+        List<List<?>> results = new ArrayList<>();
+        List<Board> boardList = boardRepository.findAllByLatitudeAndLongitude(address.getLatitude(), address.getLongitude());
+        List<MarkerResponseDto> markerList = boardList.stream().map(MarkerResponseDto::new).collect(Collectors.toList());
+        List<OverlayResponseDto> overlayList = boardList.stream().map(OverlayResponseDto::new).collect(Collectors.toList());
+        results.add(markerList);
+        results.add(overlayList);
+        return results;
     }
-     */
+
+
+
+    /*
+    @Transactional(readOnly = true)
+    public JSONArray findNearPlacesJSON(){
+
+        List<PlaceResponseDTO> DTOlist = boardRepository.findAllByLatitudeAndLongitude(37.48603206504228,126.98308494303069)
+                .stream().map(PlaceResponseDTO::new).collect(Collectors.toList());
+
+        //JSON Object --> { "":""}
+        //JSON Array --> [ , , , ]
+
+        JSONArray jsonArray = new JSONArray();
+
+        for(PlaceResponseDTO dto: DTOlist){
+            JSONObject jo = new JSONObject();
+            jo.put("idx",dto.getIdx());
+            jo.put("title",dto.getTitle());
+            jo.put("content",dto.getContent());
+            jo.put("latitude",dto.getLatitude());
+            jo.put("longitude",dto.getLongitude());
+
+            jsonArray.add(jo);
+        }
+
+        return jsonArray;
+    }
+    */
+
 }

--- a/src/main/resources/static/js/app/form.js
+++ b/src/main/resources/static/js/app/form.js
@@ -12,85 +12,83 @@ const form = {
         });
     },
 
-    getLocation : function (){
-        let lat = 37.498095, //강남역
-            lon = 127.027610;
+    getLocation : function (callback){
         if (navigator.geolocation) {
-            navigator.geolocation.getCurrentPosition(function(position){
-                lat = position.coords.latitude;
-                lon = position.coords.longitude;
-            });
+            navigator.geolocation.getCurrentPosition(callback);
         } else {
-            alert("Geolocation is not supported by this browser.");
+            alert('사용자의 브라우저는 지오로케이션을 지원하지 않습니다.');
         }
-        return [lat,lon];
     },
 
+    // NOTE: 콜백함수 흐름 공부하기...
     save : function () {
+        this.getLocation(function (position){
 
-        let [lat,lon] = this.getLocation();
-        console.log("currentPos",lat,lon);
+            let lat = position.coords.latitude,
+                lon = position.coords.longitude;
 
-        const jsonData = JSON.stringify({
-            //idx: $('#board_idx').val(), // 기본 키 생성은 데이터베이스에 위임
-            categoryType: $('#board_category').val(),
-            title: $('#board_title').val(),
-            content: $('#board_content').val(),
-            // 처음 글 올릴때는 무조건 판매중 따라서 statusType 필요없음
-            latitude: lat,
-            longitude: lon,
+            const jsonData = JSON.stringify({
+                //idx: $('#board_idx').val(), // 기본 키 생성은 데이터베이스에 위임
+                categoryType: $('#board_category').val(),
+                title: $('#board_title').val(),
+                content: $('#board_content').val(),
+                // 처음 글 올릴때는 무조건 판매중 따라서 statusType 필요없음
+                latitude: lat,
+                longitude: lon,
+            });
+            console.log("jsonData: ",jsonData); //ok
+            $.ajax({
+                url: "http://localhost:8080/api/boards",
+                type: "POST",
+                data: jsonData,
+                contentType: "application/json",
+                dataType: "json",
+                success: function () {
+                    alert('저장 성공!');
+                    location.href = '/board/list';
+                },
+                error: function () {
+                    alert('저장 실패!');
+                }
+            });
         });
-        console.log("jsonData: ",jsonData); //ok
-        $.ajax({
-                    url: "http://localhost:8080/api/boards",
-                    type: "POST",
-                    data: jsonData,
-                    contentType: "application/json",
-                    dataType: "json",
-                        success: function () {
-                            alert('저장 성공!');
-                            location.href = '/board/list';
-                    },
-                    error: function () {
-                        alert('저장 실패!');
-                        console.log("code:"+request.status+"\n"+"message:"+request.responseText+"\n"+"error:"+error);
-                    }
-               });
+
     },
     // TODO 저장 버튼 누르고 게시글 목록으로 돌아간 다음 '뒤로 가기' 누르면 잘못된 접근입니다. 띄워줘야함
 
     update : function () {
+        this.getLocation(function (position) {
 
-        let [lat,lon] = this.getLocation();
-        console.log("currentPos",lat,lon);
+            let lat = position.coords.latitude,
+                lon = position.coords.longitude;
 
-        const jsonData = JSON.stringify({
-            categoryType: $('#board_category').val(),
-            title: $('#board_title').val(),
-            content: $('#board_content').val(),
-            statusType: $('#board_status').val(),
-            latitude: lat,
-            longitude: lon,
+            const jsonData = JSON.stringify({
+                categoryType: $('#board_category').val(),
+                title: $('#board_title').val(),
+                content: $('#board_content').val(),
+                statusType: $('#board_status').val(),
+                latitude: lat,
+                longitude: lon,
+            });
+            console.log("jsonData: ",jsonData); //ok
+            const idx = $('#board_idx').val();
+
+            $.ajax({
+                url: "http://localhost:8080/api/boards/" + idx,
+                type: "PUT",
+                data: jsonData,
+                contentType: "application/json",
+                dataType: "json",
+                success: function () {
+                    alert('수정 성공!');
+                    location.href = '/board/list';
+                },
+                error: function () {
+                    alert('수정 실패!');
+                }
+            });
         });
-
-        const idx = $('#board_idx').val();
-
-        $.ajax({
-           url: "http://localhost:8080/api/boards/" + idx,
-           type: "PUT",
-           data: jsonData,
-           contentType: "application/json",
-           dataType: "json",
-           success: function () {
-               alert('수정 성공!');
-               location.href = '/board/list';
-           },
-           error: function () {
-               alert('수정 실패!');
-           }
-       });
     },
-
     delete : function () {
         const idx = $('#board_idx').val();
 

--- a/src/main/resources/static/js/app/place.js
+++ b/src/main/resources/static/js/app/place.js
@@ -1,0 +1,40 @@
+const place = {
+    init : function (){
+        const _this = this;
+        $('#btn-findNearPlaces').on('click', function(){
+            _this.findNearPlaces();
+        });
+    },
+
+    getLocation : function (callback){
+        if (navigator.geolocation) {
+            navigator.geolocation.getCurrentPosition(callback);
+        } else {
+            alert('사용자의 브라우저는 지오로케이션을 지원하지 않습니다.');
+        }
+    },
+
+    // place.html의 장소불러오기 버튼을 누르면 현재 위치에서 가까운 판매글 불러옴
+    findNearPlaces : function() {
+        this.getLocation( function (position){
+
+            let lat = position.coords.latitude,
+                lon = position.coords.longitude;
+
+            $.ajax({
+                url : "http://localhost:8080/api/places",
+                type : "GET",
+                data : { lat: lat, lon:lon },
+                dataType: 'text',
+                success: function (data) {
+                    alert('현재 위치 수집 성공!');
+                },
+                error: function (data) {
+                    alert('현재 위치 수집 실패!');
+                }
+            });
+        });
+    }
+}
+
+place.init()

--- a/src/main/resources/static/js/app/place.js
+++ b/src/main/resources/static/js/app/place.js
@@ -28,6 +28,9 @@ const place = {
                 dataType: 'text',
                 success: function (data) {
                     alert('현재 위치 수집 성공!');
+                    //console.log(data); //ok
+                    createPlaceObjects(data);
+
                 },
                 error: function (data) {
                     alert('현재 위치 수집 실패!');

--- a/src/main/resources/static/js/app/place.js
+++ b/src/main/resources/static/js/app/place.js
@@ -21,6 +21,8 @@ const place = {
             let lat = position.coords.latitude,
                 lon = position.coords.longitude;
 
+            console.log("현재위치:",lat,",",lon);
+
             $.ajax({
                 url : "http://localhost:8080/api/places",
                 type : "GET",
@@ -29,7 +31,15 @@ const place = {
                 success: function (data) {
                     alert('현재 위치 수집 성공!');
                     //console.log(data); //ok
-                    createPlaceObjects(data);
+                    let places = createPlaceObjects(data);//customOverlay;
+                    places.forEach((place) => {
+                        let marker = place.marker;
+                        let customOverlay = place.customOverlay;
+                        console.log("marker",marker); //ok
+                        console.log("customOverlay",customOverlay); //ok
+                        marker.setMap(map);
+                        customOverlay.setMap(map);
+                    });
 
                 },
                 error: function (data) {

--- a/src/main/resources/static/js/kakao-map/createContent.js
+++ b/src/main/resources/static/js/kakao-map/createContent.js
@@ -1,0 +1,51 @@
+function createContent(idx,category,title,content){
+    let div = document.createElement("div");
+    div.setAttribute("class", "overlaybox"); // overlay_info
+
+    let a = document.createElement("a");
+    a.setAttribute("class","link");
+    a.setAttribute("href", '/board/form?idx='+idx);
+    a.setAttribute("target","_blank");
+    div.appendChild(a);
+
+    let strong = document.createElement("strong");
+    strong.innerHTML = title;
+    a.appendChild(strong);
+
+    let div2 = document.createElement("div");
+    div2.setAttribute("class", "desc");
+    div.appendChild(div2);
+    /*
+    let img = document.createElement("img");
+    img.setAttribute("class", "max-small");
+    img.setAttribute("src","FIXME"); // TODO: 사진...
+    img.setAttribute("alt","사진없음");
+    div2.appendChild(img);
+    */
+    let br = document.createElement("br");
+    div2.appendChild(br);
+
+    let br2 = document.createElement("br");
+    div2.appendChild(br2);
+
+    let a2 = document.createElement("a");
+    a2.setAttribute("href", '/board/form?idx='+idx); // FIXME 일단은 게시판으로 이동하도록
+    a2.setAttribute("target", "_blank");
+    div2.appendChild(a2);
+
+    let span = document.createElement("span");
+    span.setAttribute("class","address");
+    span.innerHTML = content;
+    a2.appendChild(span);
+
+    return div;
+
+    /*
+     * <div>
+     *   <a><strong>
+     *   <div2>
+     *   	<img>
+     *   	<span>
+     */
+
+}

--- a/src/main/resources/static/js/kakao-map/createCustomOverlay.js
+++ b/src/main/resources/static/js/kakao-map/createCustomOverlay.js
@@ -1,20 +1,22 @@
-let content;
-
+let result;
 //커스텀오버레이 객체 생성하고 리턴하는 함수
 function createCustomOverlay(location, idx, category, title, content){
     // 커스텀 오버레이에 표출될 내용으로 HTML 문자열이나 document element가 가능합니다
     //일단 document.createElement로 만든 HTMLElement를 content로 넘겨주시는 방식으로 변경하셔야 합니다.
 
-    //console.log("content",content); //ok
+
+    result = createContent(idx, category, title, content);
+    //console.log("result",result); //ok
     return new kakao.maps.CustomOverlay({
         location: location,
-        content: createContent(idx, category, title, content), // DOM 객체 생성
+        content: result, // DOM 객체 생성
         //xAnchor: 0.3,
         yAnchor: 1.1
     });
+
 }
 
 
 function getContent(){
-    return content;
+    return result;
 }

--- a/src/main/resources/static/js/kakao-map/createCustomOverlay.js
+++ b/src/main/resources/static/js/kakao-map/createCustomOverlay.js
@@ -7,8 +7,9 @@ function createCustomOverlay(location, idx, category, title, content){
 
     result = createContent(idx, category, title, content);
     //console.log("result",result); //ok
+    console.log("location in createCustomOverlay",location);
     return new kakao.maps.CustomOverlay({
-        location: location,
+        position: location,
         content: result, // DOM 객체 생성
         //xAnchor: 0.3,
         yAnchor: 1.1

--- a/src/main/resources/static/js/kakao-map/createCustomOverlay.js
+++ b/src/main/resources/static/js/kakao-map/createCustomOverlay.js
@@ -1,0 +1,20 @@
+let content;
+
+//커스텀오버레이 객체 생성하고 리턴하는 함수
+function createCustomOverlay(location, idx, category, title, content){
+    // 커스텀 오버레이에 표출될 내용으로 HTML 문자열이나 document element가 가능합니다
+    //일단 document.createElement로 만든 HTMLElement를 content로 넘겨주시는 방식으로 변경하셔야 합니다.
+
+    //console.log("content",content); //ok
+    return new kakao.maps.CustomOverlay({
+        location: location,
+        content: createContent(idx, category, title, content), // DOM 객체 생성
+        //xAnchor: 0.3,
+        yAnchor: 1.1
+    });
+}
+
+
+function getContent(){
+    return content;
+}

--- a/src/main/resources/static/js/kakao-map/createMap.js
+++ b/src/main/resources/static/js/kakao-map/createMap.js
@@ -1,9 +1,9 @@
 /////////////////////////지도///////////////////////////////////
-const mapContainer = document.getElementById('map'), // 지도를 표시할 div
+let mapContainer = document.getElementById('map'), // 지도를 표시할 div
     mapOption = {
-        center: new kakao.maps.LatLng(37.48603206504228,126.98308494303069 ), // 지도의 중심좌표
+        center: new kakao.maps.LatLng(37.498095,127.027610), // 지도의 중심좌표(default 강남역)
         level: 3 // 지도의 확대 레벨
     };
 
-const map = new kakao.maps.Map(mapContainer, mapOption); // 지도를 생성합니다
+let map = new kakao.maps.Map(mapContainer, mapOption); // 지도를 생성합니다
 /////////////////////////////////////////////////////////////////

--- a/src/main/resources/static/js/kakao-map/createPlaceObjects.js
+++ b/src/main/resources/static/js/kakao-map/createPlaceObjects.js
@@ -27,14 +27,10 @@ function createPlaceObjects(jsonData) {
     var places = [];
 
     const jsonParse = JSON.parse(jsonData);
-    // jsonParse.forEach((json.forEach( (data => console.log(data)))) ); //ok
-
 
     jsonParse.forEach( (json) => {
-        // console.log("json"); //ok
-        json.forEach((data) => {  // jsonParse.forEach((data) => {
 
-            // console.log(data, typeof (data)); //ok // {idx: 191, categoryType: 'ELECTRONICS', title: '게시글191', latitude: 37.4965883, longitude: 126.9939492} 'object'
+        json.forEach((data) => {
 
             const idx = data.idx; //ok
             const category = data.categoryType; //ok
@@ -43,17 +39,8 @@ function createPlaceObjects(jsonData) {
             const latitude = data.latitude; //ok
             const longitude = data.longitude; //ok
 
-
-            // console.log(idx); //ok
-            // console.log(category); //ok
-            // console.log(title); //ok
-            // console.log("content",content); //ok
-            // console.log(latitude,"json type:",typeof(latitude),37.4965883, typeof(37.4965883)); //ok 타입은 같은데..
-            // console.log(longitude); //ok
-
             const location = new kakao.maps.LatLng(latitude,longitude);
-            console.log("idx",idx,"location",location);
-            // '<i className="fa-solid fa-clothes-hanger"></i>'
+
             //const markerImage = createMarkerImage("src", new kakao.maps.Size(30,30)); //FIXME
 
             //marker = createMarker(location, markerImage);
@@ -66,49 +53,13 @@ function createPlaceObjects(jsonData) {
         });
     });
 
-
-
-    /*
-    const jsonMarkers = jsonParse[0]; //ok
-    const jsonOverlays = jsonParse[1]; //ok
-    console.log(markers); //ok
-    console.log(overlays); //ok
-
-    jsonMarkers.forEach((jsonMarker) => {
-
-        const location = new kakao.maps.LatㅜLng(jsonMarker[latitude], jsonMarker[longitude]);
-        const markerImage = createMarkerImage(<i className="fa-solid fa-clothes-hanger"></i>, new kakao.maps.Size(30,30));
-
-        const marker = createMarker(location, markerImage);
-
-        kakao.maps.event.addListener(marker, 'mouseover', makeOverListener(map,marker,i,customOverlay));
-        kakao.maps.event.addListener(marker, 'mouseout', makeOutListener(customOverlay));
-
-    });
-
-    jsonOverlays.forEach((jsonOverlay) => {
-        const location = new kakao.maps.LatLng(jsonOverlay[latitude], jsonOverlay[longitude]);
-        const customOverlay = createCustomOverlay(position ,jsonOverlay[categoryType],i);
-    });
-     */
-
-    /*
-    getContent().addEventListener('mouseover', makeOverListener(map,marker,i,customOverlay));
-    getContent().addEventListener('mouseout', makeOutListener(customOverlay));
-
-    const place = new NewPlace(marker, customOverlay);
-    places.push(place);
-
-    */
     return places;
 
 }
 
 
-
 var activeId = null;
 var timeoutId = null;
-
 
 //커스텀오버레이를 표시하는 클로저를 만드는 함수입니다
 function makeOverListener(map,marker,customOverlay) {

--- a/src/main/resources/static/js/kakao-map/createPlaceObjects.js
+++ b/src/main/resources/static/js/kakao-map/createPlaceObjects.js
@@ -1,3 +1,5 @@
+
+
 ///장소 객체 초기화하는 함수
 function NewPlace(marker, customOverlay){
     this.marker = marker;
@@ -27,36 +29,44 @@ function createPlaceObjects(jsonData) {
     const jsonParse = JSON.parse(jsonData);
     // jsonParse.forEach((json.forEach( (data => console.log(data)))) ); //ok
 
+
     jsonParse.forEach( (json) => {
-        console.log("json");
+        // console.log("json"); //ok
         json.forEach((data) => {  // jsonParse.forEach((data) => {
 
             // console.log(data, typeof (data)); //ok // {idx: 191, categoryType: 'ELECTRONICS', title: '게시글191', latitude: 37.4965883, longitude: 126.9939492} 'object'
-            console.log("hi");
-            const idx = data.idx;
-            const category = data.categoryType;
-            const title = data.title;
-            const latitude = data.latitude;
-            const longitude = data.longitude;
 
-            console.log(idx); //ok
-            console.log(category); //ok
-            console.log(title); //ok
-            console.log(latitude); //ok
-            console.log(longitude); //ok
+            const idx = data.idx; //ok
+            const category = data.categoryType; //ok
+            const title = data.title; //ok
+            const content = data.content; //ok
+            const latitude = data.latitude; //ok
+            const longitude = data.longitude; //ok
 
-            /*
-            const location = new kakao.maps.LatLng(data["latitude"], data["longitude"]);
-            const markerImage = createMarkerImage(<i className="fa-solid fa-clothes-hanger"></i>, new kakao.maps.Size(30,30));
 
-            const marker = createMarker(location, markerImage);
-            const customOverlay = createCustomOverlay(location, data);
+            // console.log(idx); //ok
+            // console.log(category); //ok
+            // console.log(title); //ok
+            // console.log("content",content); //ok
+            // console.log(latitude,"json type:",typeof(latitude),37.4965883, typeof(37.4965883)); //ok 타입은 같은데..
+            // console.log(longitude); //ok
 
-            kakao.maps.event.addListener(marker, 'mouseover', makeOverListener(map,marker,i,customOverlay));
-            kakao.maps.event.addListener(marker, 'mouseout', makeOutListener(customOverlay));
-            */
+            const location = new kakao.maps.LatLng(latitude,longitude);
+            console.log("idx",idx,"location",location);
+            // '<i className="fa-solid fa-clothes-hanger"></i>'
+            //const markerImage = createMarkerImage("src", new kakao.maps.Size(30,30)); //FIXME
+
+            //marker = createMarker(location, markerImage);
+            var customOverlay = createCustomOverlay(location, idx, category, title, content);
+            console.log("customOverlay",customOverlay);
+            customOverlay.setMap(map);
+            //kakao.maps.event.addListener(marker, 'mouseover', makeOverListener(map,marker,customOverlay));
+            //kakao.maps.event.addListener(marker, 'mouseout', makeOutListener(customOverlay));
+
         });
     });
+
+
 
     /*
     const jsonMarkers = jsonParse[0]; //ok
@@ -66,7 +76,7 @@ function createPlaceObjects(jsonData) {
 
     jsonMarkers.forEach((jsonMarker) => {
 
-        const location = new kakao.maps.LatLng(jsonMarker[latitude], jsonMarker[longitude]);
+        const location = new kakao.maps.LatㅜLng(jsonMarker[latitude], jsonMarker[longitude]);
         const markerImage = createMarkerImage(<i className="fa-solid fa-clothes-hanger"></i>, new kakao.maps.Size(30,30));
 
         const marker = createMarker(location, markerImage);
@@ -82,8 +92,6 @@ function createPlaceObjects(jsonData) {
     });
      */
 
-
-
     /*
     getContent().addEventListener('mouseover', makeOverListener(map,marker,i,customOverlay));
     getContent().addEventListener('mouseout', makeOutListener(customOverlay));
@@ -94,8 +102,36 @@ function createPlaceObjects(jsonData) {
     */
     return places;
 
+}
 
 
+
+var activeId = null;
+var timeoutId = null;
+
+
+//커스텀오버레이를 표시하는 클로저를 만드는 함수입니다
+function makeOverListener(map,marker,customOverlay) {
+    return function(){
+        if (timeoutId !== null && i === activeId) {
+            window.clearTimeout(timeoutId);
+            timeoutId = null;
+            return;
+        }
+        customOverlay.setMap(map);
+        activeId = i;
+    }
+}
+
+// 커스텀오버레이를 닫는 클로저를 만드는 함수입니다
+function makeOutListener(customOverlay) {
+    return function(){
+        timeoutId = window.setTimeout(function() {
+            customOverlay.setMap(null);
+            activeId = null;
+            timeoutId = null;
+        }, 50);
+    }
 }
 
 

--- a/src/main/resources/static/js/kakao-map/createPlaceObjects.js
+++ b/src/main/resources/static/js/kakao-map/createPlaceObjects.js
@@ -8,18 +8,16 @@ function NewPlace(marker, customOverlay){
 
 //마커이미지의 주소와, 크기, 옵션으로 마커 이미지를 생성하여 리턴하는 함수입니다
 function createMarkerImage(src, size) {
-    const markerImage = new kakao.maps.MarkerImage(src, size);
-    return markerImage;
+    return new kakao.maps.MarkerImage(src, size);
 }
 
 // 좌표와 마커이미지를 받아 마커를 생성하여 리턴하는 함수입니다
 function createMarker(position, image) {
-    var marker = new kakao.maps.Marker({
+
+    return new kakao.maps.Marker({
         position: position,
         image: image
     });
-
-    return marker;
 }
 
 function createPlaceObjects(jsonData) {
@@ -32,27 +30,33 @@ function createPlaceObjects(jsonData) {
 
         json.forEach((data) => {
 
-            const idx = data.idx; //ok
-            const category = data.categoryType; //ok
-            const title = data.title; //ok
-            const content = data.content; //ok
-            const latitude = data.latitude; //ok
-            const longitude = data.longitude; //ok
+            let idx = data.idx; //ok
+            let category = data.categoryType; //ok
+            let title = data.title; //ok
+            let content = data.content; //ok
+            let latitude = data.latitude; //ok
+            let longitude = data.longitude; //ok
 
-            const location = new kakao.maps.LatLng(latitude,longitude);
+            let location = new kakao.maps.LatLng(latitude,longitude);
 
-            //const markerImage = createMarkerImage("src", new kakao.maps.Size(30,30)); //FIXME
+            let markerImage = createMarkerImage('https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_red.png', new kakao.maps.Size(30,30));
+            let marker = createMarker(location, markerImage);
 
-            //marker = createMarker(location, markerImage);
-            var customOverlay = createCustomOverlay(location, idx, category, title, content);
-            console.log("customOverlay",customOverlay);
-            customOverlay.setMap(map);
-            //kakao.maps.event.addListener(marker, 'mouseover', makeOverListener(map,marker,customOverlay));
-            //kakao.maps.event.addListener(marker, 'mouseout', makeOutListener(customOverlay));
+            let customOverlay = createCustomOverlay(location, idx, category, title, content);
+
+            kakao.maps.event.addListener(marker, 'mouseover', makeOverListener(map,marker,idx,customOverlay));
+            kakao.maps.event.addListener(marker, 'mouseout', makeOutListener(customOverlay));
+
+            //console.log("getContent()",getContent()); //ok
+            getContent().addEventListener('mouseover', makeOverListener(map,marker,idx,customOverlay));
+            getContent().addEventListener('mouseout', makeOutListener(customOverlay));
+
+            let place = new NewPlace(marker, customOverlay);
+            places.push(place);
 
         });
     });
-
+    //console.log("places:",places); // ok
     return places;
 
 }
@@ -62,15 +66,15 @@ var activeId = null;
 var timeoutId = null;
 
 //커스텀오버레이를 표시하는 클로저를 만드는 함수입니다
-function makeOverListener(map,marker,customOverlay) {
+function makeOverListener(map,marker,idx,customOverlay) {
     return function(){
-        if (timeoutId !== null && i === activeId) {
+        if (timeoutId !== null && idx === activeId) {
             window.clearTimeout(timeoutId);
             timeoutId = null;
             return;
         }
         customOverlay.setMap(map);
-        activeId = i;
+        activeId = idx;
     }
 }
 

--- a/src/main/resources/static/js/kakao-map/createPlaceObjects.js
+++ b/src/main/resources/static/js/kakao-map/createPlaceObjects.js
@@ -26,31 +26,75 @@ function createPlaceObjects(jsonData) {
 
     const jsonParse = JSON.parse(jsonData);
     // jsonParse.forEach((json.forEach( (data => console.log(data)))) ); //ok
-    const markers = jsonParse[0]; //ok
-    const overlays = jsonParse[1]; //ok
+
+    jsonParse.forEach( (json) => {
+        console.log("json");
+        json.forEach((data) => {  // jsonParse.forEach((data) => {
+
+            // console.log(data, typeof (data)); //ok // {idx: 191, categoryType: 'ELECTRONICS', title: '게시글191', latitude: 37.4965883, longitude: 126.9939492} 'object'
+            console.log("hi");
+            const idx = data.idx;
+            const category = data.categoryType;
+            const title = data.title;
+            const latitude = data.latitude;
+            const longitude = data.longitude;
+
+            console.log(idx); //ok
+            console.log(category); //ok
+            console.log(title); //ok
+            console.log(latitude); //ok
+            console.log(longitude); //ok
+
+            /*
+            const location = new kakao.maps.LatLng(data["latitude"], data["longitude"]);
+            const markerImage = createMarkerImage(<i className="fa-solid fa-clothes-hanger"></i>, new kakao.maps.Size(30,30));
+
+            const marker = createMarker(location, markerImage);
+            const customOverlay = createCustomOverlay(location, data);
+
+            kakao.maps.event.addListener(marker, 'mouseover', makeOverListener(map,marker,i,customOverlay));
+            kakao.maps.event.addListener(marker, 'mouseout', makeOutListener(customOverlay));
+            */
+        });
+    });
+
+    /*
+    const jsonMarkers = jsonParse[0]; //ok
+    const jsonOverlays = jsonParse[1]; //ok
     console.log(markers); //ok
     console.log(overlays); //ok
-    /*
-    jsonParse.forEach((json.forEach( (data) =>{
-        const position = dramaPositions[i].position;
-        const markerImage = createMarkerImage("media/dramaICON.png", new kakao.maps.Size(30, 30));
 
-        const marker = createMarker(position, markerImage);
-        const customOverlay = createCustomOverlay(position,"drama",i);
+    jsonMarkers.forEach((jsonMarker) => {
+
+        const location = new kakao.maps.LatLng(jsonMarker[latitude], jsonMarker[longitude]);
+        const markerImage = createMarkerImage(<i className="fa-solid fa-clothes-hanger"></i>, new kakao.maps.Size(30,30));
+
+        const marker = createMarker(location, markerImage);
 
         kakao.maps.event.addListener(marker, 'mouseover', makeOverListener(map,marker,i,customOverlay));
         kakao.maps.event.addListener(marker, 'mouseout', makeOutListener(customOverlay));
 
-        getContent().addEventListener('mouseover', makeOverListener(map,marker,i,customOverlay));
-        getContent().addEventListener('mouseout', makeOutListener(customOverlay));
+    });
 
-        const place = new NewPlace(marker, customOverlay);
-        places.push(place);
-    })) );
+    jsonOverlays.forEach((jsonOverlay) => {
+        const location = new kakao.maps.LatLng(jsonOverlay[latitude], jsonOverlay[longitude]);
+        const customOverlay = createCustomOverlay(position ,jsonOverlay[categoryType],i);
+    });
+     */
 
+
+
+    /*
+    getContent().addEventListener('mouseover', makeOverListener(map,marker,i,customOverlay));
+    getContent().addEventListener('mouseout', makeOutListener(customOverlay));
+
+    const place = new NewPlace(marker, customOverlay);
+    places.push(place);
+
+    */
     return places;
 
-     */
+
 
 }
 

--- a/src/main/resources/static/js/kakao-map/createPlaceObjects.js
+++ b/src/main/resources/static/js/kakao-map/createPlaceObjects.js
@@ -12,10 +12,10 @@ function createMarkerImage(src, size) {
 }
 
 // 좌표와 마커이미지를 받아 마커를 생성하여 리턴하는 함수입니다
-function createMarker(position, image) {
+function createMarker(location, image) {
 
     return new kakao.maps.Marker({
-        position: position,
+        position: location,
         image: image
     });
 }

--- a/src/main/resources/static/js/kakao-map/createPlaceObjects.js
+++ b/src/main/resources/static/js/kakao-map/createPlaceObjects.js
@@ -1,0 +1,57 @@
+///장소 객체 초기화하는 함수
+function NewPlace(marker, customOverlay){
+    this.marker = marker;
+    this.customOverlay = customOverlay;
+}
+
+//마커이미지의 주소와, 크기, 옵션으로 마커 이미지를 생성하여 리턴하는 함수입니다
+function createMarkerImage(src, size) {
+    const markerImage = new kakao.maps.MarkerImage(src, size);
+    return markerImage;
+}
+
+// 좌표와 마커이미지를 받아 마커를 생성하여 리턴하는 함수입니다
+function createMarker(position, image) {
+    var marker = new kakao.maps.Marker({
+        position: position,
+        image: image
+    });
+
+    return marker;
+}
+
+function createPlaceObjects(jsonData) {
+
+    var places = [];
+
+    const jsonParse = JSON.parse(jsonData);
+    // jsonParse.forEach((json.forEach( (data => console.log(data)))) ); //ok
+    const markers = jsonParse[0]; //ok
+    const overlays = jsonParse[1]; //ok
+    console.log(markers); //ok
+    console.log(overlays); //ok
+    /*
+    jsonParse.forEach((json.forEach( (data) =>{
+        const position = dramaPositions[i].position;
+        const markerImage = createMarkerImage("media/dramaICON.png", new kakao.maps.Size(30, 30));
+
+        const marker = createMarker(position, markerImage);
+        const customOverlay = createCustomOverlay(position,"drama",i);
+
+        kakao.maps.event.addListener(marker, 'mouseover', makeOverListener(map,marker,i,customOverlay));
+        kakao.maps.event.addListener(marker, 'mouseout', makeOutListener(customOverlay));
+
+        getContent().addEventListener('mouseover', makeOverListener(map,marker,i,customOverlay));
+        getContent().addEventListener('mouseout', makeOutListener(customOverlay));
+
+        const place = new NewPlace(marker, customOverlay);
+        places.push(place);
+    })) );
+
+    return places;
+
+     */
+
+}
+
+

--- a/src/main/resources/templates/place.html
+++ b/src/main/resources/templates/place.html
@@ -10,15 +10,15 @@
     <div th:replace="layout/header::header"></div>
 
     <!--body-->
-    <button type="button" class="btn btn-primary" id="btn_findNearPlaces">장소불러오기</button>
-    <div id="map" style="width:500px;height:400px;"></div>
+    <button type="button" class="btn btn-primary" id="btn-findNearPlaces">근처 판매글 불러오기</button>
+    <div id="map" style="width:1000px;height:800px;"></div>
     <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=f63a467df66083374b05cd46e6144a23"></script>
     <script type="text/javascript" src="js/kakao-map/createMap.js"></script>
-    <script src="js/app/place.js"></script>
     <!--/body-->
 
     <div th:replace="layout/footer::footer"></div>
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+    <script src="js/app/place.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/place.html
+++ b/src/main/resources/templates/place.html
@@ -3,6 +3,28 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <title>Place Page</title>
+    <style>
+        .overlaybox {position:relative;width:360px;height:350px;background:url('https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/box_movie.png') no-repeat;padding:15px 10px;}
+        .overlaybox div, ul {overflow:hidden;margin:0;padding:0;}
+        .overlaybox li {list-style: none;}
+        .overlaybox .boxtitle {color:#fff;font-size:16px;font-weight:bold;background: url('https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/arrow_white.png') no-repeat right 120px center;margin-bottom:8px;}
+        .overlaybox .first {position:relative;width:247px;height:136px;background: url('https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/thumb.png') no-repeat;margin-bottom:8px;}
+        .first .text {color:#fff;font-weight:bold;}
+        .first .triangle {position:absolute;width:48px;height:48px;top:0;left:0;background: url('https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/triangle.png') no-repeat; padding:6px;font-size:18px;}
+        .first .movietitle {position:absolute;width:100%;bottom:0;background:rgba(0,0,0,0.4);padding:7px 15px;font-size:14px;}
+        .overlaybox ul {width:247px;}
+        .overlaybox li {position:relative;margin-bottom:2px;background:#2b2d36;padding:5px 10px;color:#aaabaf;line-height: 1;}
+        .overlaybox li span {display:inline-block;}
+        .overlaybox li .number {font-size:16px;font-weight:bold;}
+        .overlaybox li .title {font-size:13px;}
+        .overlaybox ul .arrow {position:absolute;margin-top:8px;right:25px;width:5px;height:3px;background:url('https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/updown.png') no-repeat;}
+        .overlaybox li .up {background-position:0 -40px;}
+        .overlaybox li .down {background-position:0 -60px;}
+        .overlaybox li .count {position:absolute;margin-top:5px;right:15px;font-size:10px;}
+        .overlaybox li:hover {color:#fff;background:#d24545;}
+        .overlaybox li:hover .up {background-position:0 0px;}
+        .overlaybox li:hover .down {background-position:0 -20px;}
+    </style>
     <!--<link rel="stylesheet" th:href="@{/css/base.css}" />-->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
 </head>
@@ -11,9 +33,15 @@
 
     <!--body-->
     <button type="button" class="btn btn-primary" id="btn-findNearPlaces">근처 판매글 불러오기</button>
+    <script src="https://kit.fontawesome.com/8c95ccc353.js" crossorigin="anonymous"></script> <!-- 아이콘 이미지 cdn -->
     <div id="map" style="width:1000px;height:800px;"></div>
     <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=f63a467df66083374b05cd46e6144a23"></script>
     <script type="text/javascript" src="js/kakao-map/createMap.js"></script>
+    <script type="text/javascript" src="js/kakao-map/createContent.js"></script>
+    <script type="text/javascript" src="js/kakao-map/createCustomOverlay.js"></script>
+    <script type="text/javascript" src="js/kakao-map/createPlaceObjects.js"></script>
+    <!--<script type="text/javascript" src="js/kakao-map/test.js"></script>-->
+    <script type="text/javascript" src="js/kakao-map/customOverlayTest.js"></script>
     <!--/body-->
 
     <div th:replace="layout/footer::footer"></div>


### PR DESCRIPTION
# 구현한 기능
 - 카카오지도 api 연동
 - '근처 판매글 불러오기' 버튼을 누르면 DB에서 글 데이터 갖고오기 구현
 - 갖고 온 Json 데이터를 가지고 마커와 커스텀 오버레이 생성해서 지도에 띄우기

## '근처 판매글 불러오기' 버튼을 누르면 DB에서 글 데이터 갖고오기 구현
_서비스 흐름은 :one: :two: :three: :four: :five: :six: 순이고 각 계층별로 나누어 작성하였습니다._
### 프론트
#### :one: 프론트->컨트롤러
place.html의 '근처 판매글 불러오기' 버튼 누르면 place.js의 findNearPlaces함수가 사용자의 현재위치를 PlaceRestController로 보냄
#### :six: 컨트롤러 -> 프론트
place.js 의 findNearPlaces함수가 ResponseEntity의 결과를 ajax get으로 받아 지도 api 함수 실행

### 컨트롤러
#### :two: 컨트롤러->서비스
PlaceRestController의 getPlaces 함수가 사용자의 위도, 경도를 `@RequestParam`으로 받아 PlaceService의 findNearPlaces 실행

#### :five: 서비스->컨트롤러
findNearPlaces 실행결과(OverlayResponseDto 리스트)를 Optional로 감싸서 ResponseEntity에 담아보냄

### 서비스
#### :three: 서비스->리포지토리
findNearPlaces는 BoardRepository에서 위도,경도로 사용자와 가까운 데이터 찾기
>게시글을 갖고 오는 것이므로 PlaceRepository를 따로 만들지 않고 BoardRepository에서 갖고 옴
#### :four: 리포지토리->서비스
BoardRepository에서 갖고 온 글을 OverlayResponseDto로 변환
### 레포지토리
> BoardRepository는 Spring data jpa 인터페이스의 구현체로, 특정 범위의 위도,경도의 글만 찾는 JPQL 쿼리를 정의

##  갖고 온 Json 데이터를 가지고 마커와 커스텀 오버레이 생성해서 지도에 띄우기
- 카카오 지도 api의 마커와 커스텀 오버레이 사용

![screen-recording (1)](https://user-images.githubusercontent.com/95270406/158539163-78b93915-fa1f-4e70-8353-3649244b0252.gif)

# 트러블 슈팅
(아래 Review 칸에 썼습니다)